### PR TITLE
feat: read assistant messages aloud (TTS)

### DIFF
--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
-import { ChevronDown, ChevronRight, Copy, Globe, Lightbulb, RotateCcw, Pencil } from "lucide-react";
+import { ChevronDown, ChevronRight, Copy, Globe, Lightbulb, Loader2, RotateCcw, Pencil, Square, Volume2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { MessageEditInput } from "@/components/MessageEditInput";
+import { useReadAloud } from "@/hooks/use-read-aloud";
 import type { Message as MessageType } from "@/types/chats";
 
 function faviconDomain(url: string): string {
@@ -39,6 +40,7 @@ export function Message({
 	const [isSourcesExpanded, setIsSourcesExpanded] = useState(false);
 	const [isEditing, setIsEditing] = useState(false);
 	const [editedContent, setEditedContent] = useState(message.content);
+	const { isPlaying, isPreparing, toggle: toggleReadAloud } = useReadAloud();
 
 	useEffect(() => {
 		const hasOnlyThinking = message.role === "assistant" && message.thinking && !message.content;
@@ -254,6 +256,23 @@ export function Message({
 							className="h-8 px-2 text-muted-foreground hover:text-foreground hover:bg-white hover:dark:bg-card"
 						>
 							<Copy className="w-4 h-4" />
+						</Button>
+
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => toggleReadAloud(message.content)}
+							aria-label={isPlaying || isPreparing ? "Stop reading" : "Read aloud"}
+							title={isPlaying || isPreparing ? "Stop reading" : "Read aloud"}
+							className="h-8 px-2 text-muted-foreground hover:text-foreground hover:bg-white hover:dark:bg-card"
+						>
+							{isPreparing ? (
+								<Loader2 className="w-4 h-4 animate-spin" />
+							) : isPlaying ? (
+								<Square className="w-4 h-4" />
+							) : (
+								<Volume2 className="w-4 h-4" />
+							)}
 						</Button>
 
 						{isLastMessage && !isLoading && !isStreaming && (

--- a/src/hooks/use-read-aloud.ts
+++ b/src/hooks/use-read-aloud.ts
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { useAccountStore } from "@libertai/auth";
+import { useChatApiKey } from "@/hooks/data/use-chat-api-key";
+import { resolveChatEndpoint } from "@/utils/chat-endpoint";
+import env from "@/config/env";
+
+/** TTS model + voice deployed on the connected gateway (see libertai-models kokoro-82m). */
+const TTS_MODEL = "kokoro-82m";
+const TTS_VOICE = "af_heart";
+/** Matches the gateway's max input length for /v1/audio/speech. */
+const MAX_TTS_CHARS = 8192;
+
+/**
+ * Strip common Markdown syntax so the spoken text isn't littered with `*`, `#`, backticks, etc.
+ * Intentionally lightweight — good enough for natural speech, not a full Markdown parser.
+ */
+function toSpeakableText(markdown: string): string {
+	return markdown
+		.replace(/```[\s\S]*?```/g, " ") // fenced code blocks
+		.replace(/`([^`]+)`/g, "$1") // inline code
+		.replace(/!\[[^\]]*\]\([^)]*\)/g, " ") // images
+		.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1") // links -> link text
+		.replace(/^\s{0,3}#{1,6}\s+/gm, "") // headings
+		.replace(/^\s{0,3}>\s?/gm, "") // blockquotes
+		.replace(/(\*\*|__)(.*?)\1/g, "$2") // bold
+		.replace(/(\*|_)(.*?)\1/g, "$2") // italic
+		.replace(/~~(.*?)~~/g, "$1") // strikethrough
+		.replace(/^\s*[-*+]\s+/gm, "") // unordered list markers
+		.replace(/\n{2,}/g, ". ") // paragraph breaks -> pause
+		.replace(/\s+/g, " ")
+		.trim()
+		.slice(0, MAX_TTS_CHARS);
+}
+
+export type ReadAloudState = {
+	/** Audio is currently playing. */
+	isPlaying: boolean;
+	/** Request is in flight (synthesizing), before playback starts. */
+	isPreparing: boolean;
+	/** Start playback if idle, stop it if playing/preparing. */
+	toggle: (text: string) => void;
+};
+
+/**
+ * Per-message "read aloud" controller. Calls the OpenAI-compatible `/v1/audio/speech`
+ * endpoint on the connected gateway, plays the returned WAV, and exposes a play/stop toggle.
+ */
+export function useReadAloud(): ReadAloudState {
+	const isAuthenticated = useAccountStore((state) => state.isAuthenticated);
+	const { chatApiKey } = useChatApiKey();
+
+	const [isPlaying, setIsPlaying] = useState(false);
+	const [isPreparing, setIsPreparing] = useState(false);
+
+	const audioRef = useRef<HTMLAudioElement | null>(null);
+	const objectUrlRef = useRef<string | null>(null);
+	const abortRef = useRef<AbortController | null>(null);
+
+	const cleanup = useCallback(() => {
+		abortRef.current?.abort();
+		abortRef.current = null;
+		if (audioRef.current) {
+			audioRef.current.pause();
+			audioRef.current.src = "";
+			audioRef.current = null;
+		}
+		if (objectUrlRef.current) {
+			URL.revokeObjectURL(objectUrlRef.current);
+			objectUrlRef.current = null;
+		}
+		setIsPlaying(false);
+		setIsPreparing(false);
+	}, []);
+
+	// Stop and release resources if the message unmounts mid-playback.
+	useEffect(() => cleanup, [cleanup]);
+
+	const toggle = useCallback(
+		(text: string) => {
+			// Already busy → treat the click as "stop".
+			if (isPlaying || isPreparing) {
+				cleanup();
+				return;
+			}
+
+			const { baseURL, apiKey, useConnected } = resolveChatEndpoint({
+				isAuthenticated,
+				chatApiKey,
+				connectedApiUrl: env.LTAI_CONNECTED_API_URL,
+				freeApiUrl: env.LTAI_INFERENCE_API_URL,
+			});
+
+			if (!useConnected) {
+				toast.error("Sign in to read messages aloud");
+				return;
+			}
+
+			const speakable = toSpeakableText(text);
+			if (!speakable) return;
+
+			const controller = new AbortController();
+			abortRef.current = controller;
+			setIsPreparing(true);
+
+			void (async () => {
+				try {
+					const res = await fetch(`${baseURL}/audio/speech`, {
+						method: "POST",
+						headers: {
+							"Content-Type": "application/json",
+							Authorization: `Bearer ${apiKey}`,
+						},
+						body: JSON.stringify({
+							model: TTS_MODEL,
+							input: speakable,
+							voice: TTS_VOICE,
+							response_format: "wav",
+						}),
+						signal: controller.signal,
+					});
+
+					if (!res.ok) throw new Error(`TTS request failed (${res.status})`);
+
+					const blob = await res.blob();
+					if (controller.signal.aborted) return;
+
+					const url = URL.createObjectURL(blob);
+					objectUrlRef.current = url;
+
+					const audio = new Audio(url);
+					audioRef.current = audio;
+					audio.onended = cleanup;
+					audio.onerror = () => {
+						toast.error("Failed to play audio");
+						cleanup();
+					};
+
+					await audio.play();
+					if (controller.signal.aborted) return;
+					setIsPreparing(false);
+					setIsPlaying(true);
+				} catch (err) {
+					if (controller.signal.aborted || (err instanceof DOMException && err.name === "AbortError")) return;
+					console.error("Read aloud failed:", err);
+					toast.error("Failed to read message aloud");
+					cleanup();
+				}
+			})();
+		},
+		[isPlaying, isPreparing, isAuthenticated, chatApiKey, cleanup],
+	);
+
+	return { isPlaying, isPreparing, toggle };
+}


### PR DESCRIPTION
Adds a ChatGPT/Claude-style **read aloud** button to assistant messages, powered by the new LibertAI TTS endpoint (`/v1/audio/speech`, model `kokoro-82m`).

## Behavior
A speaker button sits in the existing Copy / Regenerate action row. Click it:
- `Volume2` (idle) → `Loader2` spinner (synthesizing) → `Square` (playing).
- Clicking while preparing/playing stops and resets; playback also auto-resets on end.
- Unmounting the message mid-playback aborts the request and releases the audio.

## Implementation
- `src/hooks/use-read-aloud.ts` (new) — per-message controller. Resolves the connected gateway via `resolveChatEndpoint`, POSTs to the OpenAI-compatible `/audio/speech` (`model: kokoro-82m`, `voice: af_heart`, `response_format: wav`) with the user's chat API key, plays the returned WAV via an `HTMLAudioElement`. Strips Markdown to natural speech, caps input at the gateway's 8192-char limit, and aborts cleanly on stop/unmount.
- `src/components/Message.tsx` — toggle button in the assistant-actions row with the three icon states.

## Auth
TTS requires a keyed endpoint, so for unauthenticated users the button toasts "Sign in to read messages aloud" (mirrors how other connected-gateway features gate).

## Verification
- `tsc -b` clean, `eslint --max-warnings=0` clean.
- Verified live (Playwright): button renders in the action row; guest click fires the sign-in toast.

Depends on the TTS backend (libertai-models `kokoro-82m`), already deployed to production.