### PR TITLE
fix(chat): stop re-rendering and re-persisting the whole history on every streamed token

### DIFF
--- a/e2e/file-input.spec.ts
+++ b/e2e/file-input.spec.ts
@@ -104,6 +104,10 @@ test("attaches a CSV and a text file, shows them in the composer, and persists t
 
 	// The extracted content is persisted (client-side) onto the user message, so it will be sent to
 	// the model as a labelled text block. Read it straight out of localStorage to assert on it.
+	// Persistence is write-behind (~1s debounce), so poll until the write lands.
+	await expect
+		.poll(() => page.evaluate(() => window.localStorage.getItem("libertai-chats")), { timeout: 5_000 })
+		.toContain("inventory.csv");
 	const persisted = await page.evaluate(() => window.localStorage.getItem("libertai-chats"));
 	expect(persisted).toBeTruthy();
 	const parsed = JSON.parse(persisted!);

--- a/e2e/model-picker.spec.ts
+++ b/e2e/model-picker.spec.ts
@@ -133,8 +133,10 @@ test("model picker lists real models, shows a TEE badge, and persists the select
 	await expect(trigger).toContainText("Hermes 3 8B (TEE)");
 
 	// The choice persisted to the chat store (localStorage) and survives a reload.
-	const stored = await page.evaluate(() => window.localStorage.getItem("libertai-chats"));
-	expect(stored).toContain("hermes-3-8b-tee");
+	// Persistence is write-behind (~1s debounce), so poll until the write lands.
+	await expect
+		.poll(() => page.evaluate(() => window.localStorage.getItem("libertai-chats")), { timeout: 5_000 })
+		.toContain("hermes-3-8b-tee");
 
 	await page.reload({ waitUntil: "domcontentloaded" });
 	const triggerAfterReload = page.getByTestId("model-picker-trigger");

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -123,9 +123,11 @@ test("create a project, move a chat into it, persist across reload, and set inst
 	await expect(page.getByTestId(`chat-row-${CHAT_A}`)).toBeVisible();
 	await expect(page.getByTestId(`chat-row-${CHAT_B}`)).toBeVisible();
 
-	// Persisted: the chat carries the projectId and the project record exists.
-	const chatsStored = await page.evaluate((k) => window.localStorage.getItem(k), CHATS_KEY);
-	expect(chatsStored).toContain(projectId);
+	// Persisted: the chat carries the projectId and the project record exists. The chat store's
+	// persistence is write-behind (~1s debounce), so poll until the write lands.
+	await expect
+		.poll(() => page.evaluate((k) => window.localStorage.getItem(k), CHATS_KEY), { timeout: 5_000 })
+		.toContain(projectId);
 	const projectsStored = await page.evaluate((k) => window.localStorage.getItem(k), PROJECTS_KEY);
 	expect(projectsStored).toContain("Work");
 	expect(projectsStored).toContain(projectId);

--- a/src/components/ChatList.tsx
+++ b/src/components/ChatList.tsx
@@ -15,18 +15,37 @@ import {
 	DropdownMenuSubTrigger,
 	DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useSidebar } from "@/components/ui/sidebar";
 import { Input } from "./ui/input";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "./ui/dialog";
 
 export function ChatList() {
-	const { getAllChats, deleteChat, renameChat, setChatProject } = useChatStore();
-	const { getAllProjects } = useProjectStore();
+	const deleteChat = useChatStore((s) => s.deleteChat);
+	const renameChat = useChatStore((s) => s.renameChat);
+	const setChatProject = useChatStore((s) => s.setChatProject);
+	// Subscribe to a cheap ordered signature of what the rows actually display (id / title /
+	// project link) instead of the whole store: during streaming the chat store updates many
+	// times per second, but none of those flushes change this string, so the sidebar no longer
+	// re-renders (and re-sorts every chat) on every token batch.
+	const rowsSignature = useChatStore((s) =>
+		Object.values(s.chats)
+			.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+			.map((c) => `${c.id}|${truncateText(getChatTitle(c))}|${c.projectId ?? ""}`)
+			.join("\n"),
+	);
+	// eslint-disable-next-line react-hooks/exhaustive-deps -- rowsSignature is the real dependency
+	const chats = useMemo(() => useChatStore.getState().getAllChats(), [rowsSignature]);
+	const projectsById = useProjectStore((s) => s.projects);
+	// Same ordering as getAllProjects(); computed from the subscribed record so this only
+	// recomputes on actual project changes, not on unrelated store writes.
+	const projects = useMemo(
+		() =>
+			Object.values(projectsById).sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()),
+		[projectsById],
+	);
 	const navigate = useNavigate();
 	const currentPath = location.pathname;
-	const chats = getAllChats();
-	const projects = getAllProjects();
 	const { isMobile, setOpenMobile } = useSidebar();
 
 	const [activeChat, setActiveChat] = useState<string | null>(null);

--- a/src/components/ChatSearch.tsx
+++ b/src/components/ChatSearch.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { MessageCircle, Search } from "lucide-react";
 import { Button } from "./ui/button";
@@ -19,8 +19,19 @@ export function ChatSearch() {
 	const [searchOpen, setSearchOpen] = useState(false);
 	const [searchQuery, setSearchQuery] = useState("");
 	const navigate = useNavigate();
-	const { getAllChats } = useChatStore();
-	const allChats = getAllChats();
+	// While the dialog is closed this component only needs to know whether any chats exist
+	// (sidebar button + ⌘K gate), so it subscribes to a boolean and stays inert during the
+	// ~20/s store writes of a streaming response. The full record is only subscribed while
+	// the dialog is open, which also keeps search results live.
+	const hasChats = useChatStore((s) => Object.keys(s.chats).length > 0);
+	const openChats = useChatStore((s) => (searchOpen ? s.chats : null));
+	const allChats = useMemo(
+		() =>
+			openChats
+				? Object.values(openChats).sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+				: [],
+		[openChats],
+	);
 
 	// Detect if user is on Mac
 	const isMac = typeof navigator !== "undefined" ? navigator.platform.toUpperCase().indexOf("MAC") >= 0 : false;
@@ -95,7 +106,7 @@ export function ChatSearch() {
 		const handleKeyDown = (e: KeyboardEvent) => {
 			if ((e.metaKey || e.ctrlKey) && e.key === "k") {
 				e.preventDefault();
-				if (allChats.length > 0) {
+				if (hasChats) {
 					setSearchOpen(true);
 				}
 			}
@@ -103,10 +114,10 @@ export function ChatSearch() {
 
 		document.addEventListener("keydown", handleKeyDown);
 		return () => document.removeEventListener("keydown", handleKeyDown);
-	}, [allChats.length]);
+	}, [hasChats]);
 
 	// Nothing to search until there's at least one conversation.
-	if (allChats.length === 0) {
+	if (!hasChats) {
 		return null;
 	}
 

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -1,4 +1,4 @@
-import { Children, cloneElement, isValidElement, useState, type ReactElement, type ReactNode } from "react";
+import { Children, cloneElement, isValidElement, memo, useState, type ReactElement, type ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
@@ -55,7 +55,12 @@ interface MessageProps {
 	onRegenerateFromMessage?: (id: string) => void;
 }
 
-export function Message({
+// Memoized: during streaming the chat route re-renders on every flushed token batch, and without
+// memo EVERY message re-ran the full ReactMarkdown (remark-gfm + remark-math + KaTeX) pipeline each
+// time — O(whole conversation) per flush, the main cause of slow/lumpy streaming in long chats.
+// With memo only the message whose props changed (the streaming one) re-renders. Relies on the
+// route passing referentially-stable callbacks (useStableHandler) and stable toolStatus/toolSteps.
+export const Message = memo(function Message({
 	message,
 	chatId,
 	isLastMessage,
@@ -536,4 +541,4 @@ export function Message({
 			</div>
 		</div>
 	);
-}
+});

--- a/src/hooks/use-stable-handler.ts
+++ b/src/hooks/use-stable-handler.ts
@@ -1,0 +1,12 @@
+import { useCallback, useLayoutEffect, useRef } from "react";
+
+// Returns a referentially-stable function that always invokes the latest `handler`.
+// Lets a parent pass event callbacks to memoized children (e.g. <Message/>) without the
+// callback identity changing every render, which would defeat React.memo.
+export function useStableHandler<A extends unknown[], R>(handler: (...args: A) => R): (...args: A) => R {
+	const ref = useRef(handler);
+	useLayoutEffect(() => {
+		ref.current = handler;
+	});
+	return useCallback((...args: A) => ref.current(...args), []);
+}

--- a/src/routes/chat.$chatId.tsx
+++ b/src/routes/chat.$chatId.tsx
@@ -29,6 +29,7 @@ import type { GenerateImageArgs, SearchType, InterpreterArtifact } from "@/utils
 import { consumePendingForcedTool } from "@/utils/pending-forced-tool";
 import env from "@/config/env";
 import OpenAI from "openai";
+import { useStableHandler } from "@/hooks/use-stable-handler";
 import { toast } from "sonner";
 import type { ParsedMessage } from "@/utils/thinking-parser";
 import type { ImageData, FileAttachment } from "@/types/chats";
@@ -39,17 +40,18 @@ export const Route = createFileRoute("/chat/$chatId")({
 
 function Chat() {
 	const { chatId } = Route.useParams();
-	const {
-		getChat,
-		addMessage,
-		updateMessage,
-		attachMessageMeta,
-		syncMessageArtifacts,
-		deleteMessage,
-		truncateMessagesAfter,
-		setChatModel,
-	} = useChatStore();
-	const { getAssistantOrDefault } = useAssistantStore();
+	// Individual selectors, never the bare store: a selector-less useChatStore() re-renders this
+	// route on EVERY store write — including the ~20/s streaming flushes of *other* fields — and
+	// each of those re-renders used to re-run the whole message list. Actions are referentially
+	// stable, so selecting them never re-renders; only the `chat` selector below is reactive.
+	const addMessage = useChatStore((s) => s.addMessage);
+	const updateMessage = useChatStore((s) => s.updateMessage);
+	const attachMessageMeta = useChatStore((s) => s.attachMessageMeta);
+	const syncMessageArtifacts = useChatStore((s) => s.syncMessageArtifacts);
+	const deleteMessage = useChatStore((s) => s.deleteMessage);
+	const truncateMessagesAfter = useChatStore((s) => s.truncateMessagesAfter);
+	const setChatModel = useChatStore((s) => s.setChatModel);
+	const getAssistantOrDefault = useAssistantStore((s) => s.getAssistantOrDefault);
 	const getProject = useProjectStore((s) => s.getProject);
 	// Subscribe to the memory store so the injected-context indicator re-renders when the user adds,
 	// edits, toggles or deletes a memory while this chat is open. The actual injection at send-time
@@ -81,7 +83,7 @@ function Chat() {
 	const abortRef = useRef<AbortController | null>(null);
 	const messagesEndRef = useRef<HTMLDivElement>(null);
 
-	const chat = getChat(chatId);
+	const chat = useChatStore((s) => s.chats[chatId]);
 	const messages = chat?.messages || [];
 
 	// Effective model = explicit per-chat override (set via the ModelPicker) overriding the persona's
@@ -215,16 +217,20 @@ function Chat() {
 		const collectedImages: ImageData[] = [];
 		const collectedInterpreter: InterpreterArtifact[] = [];
 
-		// Coalesce streaming writes. The route subscribes to the whole chat store, so every
-		// updateMessage re-renders it. Thinking models (e.g. Mega Mind) emit thousands of tiny
+		// Coalesce streaming writes. Thinking models (e.g. Mega Mind) emit thousands of tiny
 		// reasoning deltas that can arrive in a burst — writing per-delta floods React and trips its
 		// max-update-depth guard (#185), which surfaced as a generic "error processing your request".
-		// Flush at most once per frame and force a final flush per turn so nothing is dropped.
+		// Flush at most once per interval and force a final flush per turn so nothing is dropped.
+		// The interval widens as the message grows: each flush re-parses the streaming message's
+		// markdown (O(length)), so a fixed 50ms tick would progressively starve the main thread —
+		// and with it this very read loop — on long thinking responses.
 		const FLUSH_INTERVAL_MS = 50;
 		let lastFlush = 0;
 		const flushStreamedMessage = (force = false) => {
 			const now = Date.now();
-			if (!force && now - lastFlush < FLUSH_INTERVAL_MS) return;
+			const size = accumulated.content.length + accumulated.thinking.length;
+			const interval = Math.min(250, FLUSH_INTERVAL_MS + Math.floor(size / 10_000) * 50);
+			if (!force && now - lastFlush < interval) return;
 			lastFlush = now;
 			updateMessage(chatId, assistantMessage.id, accumulated.content, accumulated.thinking);
 		};
@@ -517,18 +523,22 @@ function Chat() {
 		addMessage(chatId, "user", value.trim(), undefined, images, attachments);
 	};
 
+	// The four handlers below are passed to the memoized <Message/> rows; useStableHandler keeps
+	// their identity constant across renders (they always call the latest closure) so React.memo
+	// can actually skip unchanged messages during streaming.
+
 	// One click to resume a turn that hit the tool-loop cap without a final answer. We keep the
 	// gathered assistant turn (sources/images/interpreter stay attached to it) and append a fresh
 	// user "Continue." so generateAIResponse takes one more round-trip to summarise. Without this the
 	// user had to type "continue" themselves after a long silent run.
-	const handleContinue = async () => {
+	const handleContinue = useStableHandler(async () => {
 		if (isLoading || isStreaming) return;
 		setContinueFromMessageId(null);
 		addMessage(chatId, "user", "Continue");
 		await generateAIResponse();
-	};
+	});
 
-	const handleRegenerateMessage = async () => {
+	const handleRegenerateMessage = useStableHandler(async () => {
 		if (isLoading || isStreaming || messages.length === 0) return;
 
 		// Find the last assistant message and regenerate it
@@ -540,18 +550,18 @@ function Chat() {
 		// Clear the last assistant message content and regenerate
 		deleteMessage(chatId, lastMessage.id);
 		await generateAIResponse();
-	};
+	});
 
-	const handleEditMessage = (messageId: string, newContent: string) => {
+	const handleEditMessage = useStableHandler((messageId: string, newContent: string) => {
 		updateMessage(chatId, messageId, newContent);
-	};
+	});
 
-	const handleRegenerateFromMessage = async (messageId: string) => {
+	const handleRegenerateFromMessage = useStableHandler(async (messageId: string) => {
 		if (isLoading || isStreaming) return;
 
 		truncateMessagesAfter(chatId, messageId);
 		await generateAIResponse();
-	};
+	});
 
 	// Show 404 if chat doesn't exist
 	if (!chat) {
@@ -574,7 +584,9 @@ function Chat() {
 								isLoading={isLoading}
 								isStreaming={isStreaming}
 								toolStatus={index === messages.length - 1 ? toolStatus : null}
-								toolSteps={index === messages.length - 1 ? toolSteps : []}
+								// undefined (not a fresh []) for non-last rows — a new array identity
+								// per render would defeat Message's memo on every streaming flush.
+								toolSteps={index === messages.length - 1 ? toolSteps : undefined}
 								needsContinue={continueFromMessageId === message.id}
 								onContinue={handleContinue}
 								onRegenerate={handleRegenerateMessage}

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { createDebouncedPersistStorage } from "@/utils/debounced-persist-storage";
 import { runMigrations } from "@/types/chats/migrations";
 import { Chat, Message, ImageData, CanvasArtifact, FileAttachment } from "@/types/chats";
 import { useAssistantStore } from "./assistant";
@@ -400,6 +401,9 @@ export const useChatStore = create<ChatStore>()(
 			name: "libertai-chats",
 			version: CHAT_VERSION,
 			migrate: runMigrations,
+			// Write-behind storage: streaming updates the store ~20×/s, and the default storage
+			// synchronously serialized the ENTIRE chat history on every one of those writes.
+			storage: createDebouncedPersistStorage(1000),
 		},
 	),
 );

--- a/src/utils/debounced-persist-storage.test.ts
+++ b/src/utils/debounced-persist-storage.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { StorageValue } from "zustand/middleware";
+import { createDebouncedPersistStorage } from "./debounced-persist-storage";
+
+// Minimal localStorage stand-in for the node test environment.
+function makeLocalStorage() {
+	const data = new Map<string, string>();
+	return {
+		getItem: (k: string) => data.get(k) ?? null,
+		setItem: vi.fn((k: string, v: string) => {
+			data.set(k, v);
+		}),
+		removeItem: (k: string) => {
+			data.delete(k);
+		},
+		data,
+	};
+}
+
+const value = (n: number): StorageValue<{ n: number }> => ({ state: { n }, version: 1 });
+
+describe("createDebouncedPersistStorage", () => {
+	let ls: ReturnType<typeof makeLocalStorage>;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		ls = makeLocalStorage();
+		vi.stubGlobal("localStorage", ls);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+	});
+
+	it("coalesces rapid writes into one serialized write after the delay", () => {
+		const storage = createDebouncedPersistStorage<{ n: number }>(1000);
+
+		for (let i = 0; i < 50; i++) storage.setItem("key", value(i));
+		expect(ls.setItem).not.toHaveBeenCalled(); // nothing written synchronously
+
+		vi.advanceTimersByTime(1000);
+		expect(ls.setItem).toHaveBeenCalledTimes(1); // one write, latest state only
+		expect(JSON.parse(ls.data.get("key")!)).toEqual(value(49));
+	});
+
+	it("serves the pending (unflushed) value from getItem", () => {
+		const storage = createDebouncedPersistStorage<{ n: number }>(1000);
+		storage.setItem("key", value(7));
+		expect(storage.getItem("key")).toEqual(value(7));
+	});
+
+	it("reads existing localStorage state synchronously (hydration path)", () => {
+		ls.data.set("key", JSON.stringify(value(3)));
+		const storage = createDebouncedPersistStorage<{ n: number }>(1000);
+		expect(storage.getItem("key")).toEqual(value(3));
+		expect(storage.getItem("missing")).toBeNull();
+	});
+
+	it("survives a quota error without throwing into the caller", () => {
+		const storage = createDebouncedPersistStorage<{ n: number }>(1000);
+		ls.setItem.mockImplementationOnce(() => {
+			throw new DOMException("quota", "QuotaExceededError");
+		});
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		storage.setItem("key", value(1));
+		expect(() => vi.advanceTimersByTime(1000)).not.toThrow();
+		expect(consoleError).toHaveBeenCalled();
+
+		// A later write still goes through.
+		storage.setItem("key", value(2));
+		vi.advanceTimersByTime(1000);
+		expect(JSON.parse(ls.data.get("key")!)).toEqual(value(2));
+		consoleError.mockRestore();
+	});
+
+	it("removeItem drops both the pending value and the stored one", () => {
+		ls.data.set("key", JSON.stringify(value(1)));
+		const storage = createDebouncedPersistStorage<{ n: number }>(1000);
+		storage.setItem("key", value(2));
+		storage.removeItem("key");
+		expect(storage.getItem("key")).toBeNull();
+		vi.advanceTimersByTime(1000);
+		expect(ls.data.has("key")).toBe(false);
+	});
+});

--- a/src/utils/debounced-persist-storage.ts
+++ b/src/utils/debounced-persist-storage.ts
@@ -1,0 +1,68 @@
+import type { PersistStorage, StorageValue } from "zustand/middleware";
+
+// Write-behind localStorage adapter for zustand's persist middleware.
+//
+// The default persist storage serializes the WHOLE store and synchronously writes it to
+// localStorage on every set(). For the chat store that meant: during streaming, every throttled
+// token flush (~20/s) paid a JSON.stringify of every conversation ever had — an O(total history)
+// main-thread block that grew with the chat and starved both rendering and the SSE read loop
+// (very slow / lumpy streaming on long thinking-model conversations). A localStorage quota error
+// also threw inside set(), breaking the stream mid-response.
+//
+// This adapter keeps hydration synchronous (getItem reads localStorage directly, so app startup
+// and the e2e localStorage seeding are unchanged) but defers writes: setItem only records the
+// latest state and schedules ONE serialize+write per `delayMs`, off the set() call path. Quota
+// errors surface as a console error instead of breaking the caller. The pending state is flushed
+// synchronously on pagehide / tab-hidden, so at most ~`delayMs` of the newest messages is at risk
+// on a hard kill.
+export function createDebouncedPersistStorage<S>(delayMs: number): PersistStorage<S> {
+	const pending = new Map<string, StorageValue<S>>();
+	let timer: ReturnType<typeof setTimeout> | null = null;
+
+	// Absent outside the browser (node unit tests); every operation degrades to a no-op then.
+	const store = typeof localStorage !== "undefined" ? localStorage : undefined;
+
+	const flush = () => {
+		if (timer !== null) {
+			clearTimeout(timer);
+			timer = null;
+		}
+		for (const [name, value] of pending) {
+			try {
+				store?.setItem(name, JSON.stringify(value));
+			} catch (error) {
+				// Quota exceeded (or storage unavailable): keep the app running on in-memory state.
+				console.error(`Failed to persist "${name}":`, error);
+			}
+		}
+		pending.clear();
+	};
+
+	if (typeof window !== "undefined") {
+		// pagehide fires on reload/close/navigation; the synchronous localStorage write completes
+		// before the document is torn down. visibilitychange covers mobile tab backgrounding.
+		window.addEventListener("pagehide", flush);
+		document.addEventListener("visibilitychange", () => {
+			if (document.visibilityState === "hidden") flush();
+		});
+	}
+
+	return {
+		getItem: (name) => {
+			// Read-your-writes: a scheduled-but-unflushed value is the freshest state.
+			const scheduled = pending.get(name);
+			if (scheduled !== undefined) return scheduled;
+			const stored = store?.getItem(name) ?? null;
+			return stored === null ? null : (JSON.parse(stored) as StorageValue<S>);
+		},
+		setItem: (name, value) => {
+			// Zustand state is immutable, so holding the reference until the flush is safe.
+			pending.set(name, value);
+			if (timer === null) timer = setTimeout(flush, delayMs);
+		},
+		removeItem: (name) => {
+			pending.delete(name);
+			store?.removeItem(name);
+		},
+	};
+}

--- a/src/utils/debounced-persist-storage.ts
+++ b/src/utils/debounced-persist-storage.ts
@@ -41,6 +41,8 @@ export function createDebouncedPersistStorage<S>(delayMs: number): PersistStorag
 	if (typeof window !== "undefined") {
 		// pagehide fires on reload/close/navigation; the synchronous localStorage write completes
 		// before the document is torn down. visibilitychange covers mobile tab backgrounding.
+		// These listeners are never removed: this factory is called exactly once, at store
+		// definition (module scope), and the adapter lives for the page's lifetime.
 		window.addEventListener("pagehide", flush);
 		document.addEventListener("visibilitychange", () => {
 			if (document.visibilityState === "hidden") flush();


### PR DESCRIPTION
## Problem

Heavy conversations with thinking models (Mega Mind → glm-5.2-thinking) streamed very slowly and in visible lumps, and could break mid-response — while the same model via direct API was fast. The gateway relays SSE unbuffered and vLLM prefix caching is on, so nothing differed on the wire: every cause was client-side work done on each streaming flush, all scaling with conversation size:

1. **Full markdown re-render**: every `<Message/>` re-ran the ReactMarkdown + remark-gfm + remark-math + KaTeX pipeline on every ~50ms flush — O(whole conversation) per flush, O(n²) over a response.
2. **Full-history persistence**: the chat store's default persist storage synchronously `JSON.stringify`'d **all** conversations (incl. attachment text and generated images) into localStorage ~20×/s. This blocked the same thread that reads the SSE stream (hence the lumpy output), and a `QuotaExceededError` inside `set()` broke the stream mid-response (same family as #185). Big file attachments made this markedly worse (up to 20k chars each, serialized on every flush).
3. **Sidebar churn**: `ChatList` subscribed to the whole store and re-sorted every chat on every write.

## Fix

- `React.memo` on `<Message/>`; new `useStableHandler` hook keeps row callbacks referentially stable; non-last rows get `undefined` toolSteps instead of a fresh `[]` — so only the actively streaming message re-renders.
- New write-behind persist storage (`debounced-persist-storage.ts`): serializes at most once per second off the `set()` path, flushes synchronously on `pagehide`/tab-hidden (reloads lose nothing; ≤1s at risk on a hard kill), and quota errors log instead of breaking the stream. Hydration stays synchronous and the storage format is unchanged, so existing users and e2e seeding are unaffected. (IndexedDB migration for quota headroom is a possible follow-up.)
- Chat route uses per-action selectors + a reactive `chats[chatId]` selector; `ChatList` subscribes to a cheap id/title/project signature.
- The streaming flush interval widens 50→250ms as the message grows, so re-parsing the streaming message's own markdown can't starve the SSE read loop at the tail of very long thinking responses.

Three e2e specs that read `localStorage["libertai-chats"]` immediately after an action now poll (≤5s) to accommodate the write-behind debounce.

## Verification

- `pnpm test`: 275/275 unit tests pass (incl. new tests for the write-behind storage)
- `pnpm lint`: clean
- `pnpm build`: clean (against the pinned `src/shared` commit)
- `pnpm e2e`: full Playwright suite 36/36 pass