### PR TITLE
feat(chat): live thinking preview, tab-freeze protection, tool-step transparency

### DIFF
--- a/e2e/thinking.spec.ts
+++ b/e2e/thinking.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect, type Page } from "@playwright/test";
+import { mkdirSync } from "node:fs";
+
+// Verifies the thinking-model plumbing end to end against a mocked SSE completion:
+//  1. `reasoning_content` deltas accumulate into the message's thinking and survive completion —
+//     the THINKING toggle renders and expanding it shows the reasoning text.
+//  2. The final answer text renders as markdown below it.
+// The live mid-stream preview (thinking tail while collapsed) can't be exercised here because
+// route.fulfill delivers the SSE body in one shot; it is covered by review + manual verification.
+
+mkdirSync("test-results/screenshots", { recursive: true });
+
+const CHAT_ID = "e2e-thinking-chat";
+const ALEPH_GLOB = "**/aggregates/**LTAI_PRICING**";
+
+// A reasoning-capable model so the -thinking variant resolves client-side.
+const REGISTRY = {
+	data: {
+		LTAI_PRICING: {
+			models: [
+				{
+					id: "glm-5.2",
+					name: "GLM 5.2",
+					pricing: { text: { price_per_million_input_tokens: 0.2, price_per_million_output_tokens: 0.8 } },
+					capabilities: {
+						text: { tee: false, vision: false, reasoning: true, context_window: 131072, function_calling: false },
+					},
+				},
+			],
+		},
+	},
+};
+
+const THINKING_TEXT = "Let me reason about prime gaps carefully before answering.";
+const ANSWER_TEXT = "The answer is that prime gaps grow, but slowly.";
+
+function sseBody(): string {
+	const chunk = (delta: Record<string, string>) =>
+		`data: ${JSON.stringify({ choices: [{ delta }] })}\n\n`;
+	const parts: string[] = [];
+	for (const word of THINKING_TEXT.split(" ")) parts.push(chunk({ reasoning_content: `${word} ` }));
+	for (const word of ANSWER_TEXT.split(" ")) parts.push(chunk({ content: `${word} ` }));
+	parts.push("data: [DONE]\n\n");
+	return parts.join("");
+}
+
+function seedThinkingChat(page: Page) {
+	const now = new Date().toISOString();
+	const persisted = {
+		state: {
+			chats: {
+				[CHAT_ID]: {
+					id: CHAT_ID,
+					// Last message is from the user so the route auto-fires a generation on load.
+					messages: [
+						{
+							id: "m1",
+							role: "user",
+							content: "How fast do prime gaps grow?",
+							timestamp: now,
+						},
+					],
+					assistantId: "light",
+					model: "glm-5.2-thinking",
+					createdAt: now,
+					updatedAt: now,
+				},
+			},
+			legacyMigrated: true,
+		},
+		version: 9,
+	};
+	return page.addInitScript(
+		([key, value]) => {
+			if (!window.localStorage.getItem(key)) window.localStorage.setItem(key, value);
+		},
+		["libertai-chats", JSON.stringify(persisted)] as const,
+	);
+}
+
+test("reasoning deltas persist as expandable thinking and the answer renders", async ({ page }) => {
+	await page.route(ALEPH_GLOB, (route) =>
+		route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(REGISTRY) }),
+	);
+	await page.route("**/v1/chat/completions", (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: "text/event-stream; charset=utf-8",
+			body: sseBody(),
+		}),
+	);
+	await seedThinkingChat(page);
+
+	await page.goto(`/chat/${CHAT_ID}`, { waitUntil: "domcontentloaded", timeout: 30_000 });
+
+	// The answer streams in and renders as the assistant message.
+	await expect(page.locator(".markdown-content", { hasText: "prime gaps grow, but slowly" })).toBeVisible({
+		timeout: 20_000,
+	});
+
+	// The THINKING toggle is present; expanding it reveals the accumulated reasoning.
+	// exact: the model-picker trigger also contains "thinking" (model id "glm-5.2-thinking").
+	const thinkingToggle = page.getByRole("button", { name: "Thinking", exact: true });
+	await expect(thinkingToggle).toBeVisible();
+	await thinkingToggle.click();
+	await expect(page.getByText("Let me reason about prime gaps carefully")).toBeVisible();
+
+	await page.screenshot({ path: "test-results/screenshots/thinking-expanded.png", fullPage: true });
+});

--- a/e2e/thinking.spec.ts
+++ b/e2e/thinking.spec.ts
@@ -82,7 +82,7 @@ test("reasoning deltas persist as expandable thinking and the answer renders", a
 	await page.route(ALEPH_GLOB, (route) =>
 		route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(REGISTRY) }),
 	);
-	await page.route("**/v1/chat/completions", (route) =>
+	await page.route("**/chat/completions", (route) =>
 		route.fulfill({
 			status: 200,
 			contentType: "text/event-stream; charset=utf-8",

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -168,7 +168,9 @@ export const Message = memo(function Message({
 	return (
 		<div className={`flex ${message.role === "user" ? "justify-end" : "justify-start"}`}>
 			<div className={`group ${message.role === "user" ? "max-w-full" : "w-full"}`}>
-				{/* Thinking section for assistant messages */}
+				{/* Thinking section for assistant messages. While the model is still reasoning (streaming,
+				    no answer text yet) a live tail of the thinking is previewed even when collapsed —
+				    otherwise a long thinking phase shows nothing for minutes and looks frozen. */}
 				{message.role === "assistant" && message.thinking && (
 					<div className="mb-3">
 						<button
@@ -184,10 +186,25 @@ export const Message = memo(function Message({
 							)}
 						</button>
 
-						{isThinkingExpanded && (
+						{isThinkingExpanded ? (
 							<div className="mt-2 px-4 py-3 bg-muted/30 rounded-lg border-l-2 border-primary/30">
 								<div className="text-sm text-muted-foreground italic whitespace-pre-wrap">{message.thinking}</div>
 							</div>
+						) : (
+							isLastMessage &&
+							isStreaming &&
+							!message.content && (
+								<div
+									className="mt-2 px-4 py-3 bg-muted/30 rounded-lg border-l-2 border-primary/30"
+									data-testid="thinking-live-preview"
+								>
+									<div className="text-sm text-muted-foreground italic whitespace-pre-wrap">
+										{/* Tail only: slicing keeps the per-flush render cost flat however long the
+										    reasoning grows. */}
+										{message.thinking.length > 500 ? `…${message.thinking.slice(-500)}` : message.thinking}
+									</div>
+								</div>
+							)
 						)}
 					</div>
 				)}
@@ -219,6 +236,7 @@ export const Message = memo(function Message({
 					(isStreaming || isLoading) &&
 					!toolStatus &&
 					(!toolSteps || toolSteps.length === 0) &&
+					!message.thinking &&
 					!(message.interpreter && message.interpreter.length > 0) && (
 						<div className="mb-3 flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground">
 							<Loader2 className="w-3.5 h-3.5 text-primary shrink-0 animate-spin" />

--- a/src/routes/chat.$chatId.tsx
+++ b/src/routes/chat.$chatId.tsx
@@ -201,6 +201,7 @@ function Chat() {
 		// freezing, so hold one for the duration of the generation ("shared" so concurrent tabs
 		// don't queue behind each other). No-op where the API is unavailable.
 		let releaseFreezeLock: (() => void) | undefined;
+		let generationSettled = false;
 		try {
 			void navigator.locks
 				?.request(
@@ -208,6 +209,12 @@ function Chat() {
 					{ mode: "shared" },
 					() =>
 						new Promise<void>((resolve) => {
+							// If the generation already settled before the lock was granted, release
+							// immediately — otherwise the lock would be held until the page closes.
+							if (generationSettled) {
+								resolve();
+								return;
+							}
 							releaseFreezeLock = resolve;
 						}),
 				)
@@ -540,6 +547,7 @@ function Chat() {
 			setToolStatus(null);
 			setToolSteps([]);
 			abortRef.current = null;
+			generationSettled = true;
 			releaseFreezeLock?.();
 			// If the user tabbed away while this generated, flag the finished answer in the title.
 			notifyResponseReady();

--- a/src/routes/chat.$chatId.tsx
+++ b/src/routes/chat.$chatId.tsx
@@ -30,6 +30,7 @@ import { consumePendingForcedTool } from "@/utils/pending-forced-tool";
 import env from "@/config/env";
 import OpenAI from "openai";
 import { useStableHandler } from "@/hooks/use-stable-handler";
+import { notifyResponseReady } from "@/utils/background-notify";
 import { toast } from "sonner";
 import type { ParsedMessage } from "@/utils/thinking-parser";
 import type { ImageData, FileAttachment } from "@/types/chats";
@@ -194,6 +195,27 @@ function Chat() {
 		const controller = new AbortController();
 		abortRef.current = controller;
 
+		// Chrome freezes fully-hidden tabs under memory/battery pressure, which suspends the SSE
+		// read loop mid-response — tab away during a long thinking phase and the stream stalls,
+		// then dumps everything at once on return. Pages holding a Web Lock are exempt from
+		// freezing, so hold one for the duration of the generation ("shared" so concurrent tabs
+		// don't queue behind each other). No-op where the API is unavailable.
+		let releaseFreezeLock: (() => void) | undefined;
+		try {
+			void navigator.locks
+				?.request(
+					"libertai-active-generation",
+					{ mode: "shared" },
+					() =>
+						new Promise<void>((resolve) => {
+							releaseFreezeLock = resolve;
+						}),
+				)
+				.catch(() => {});
+		} catch {
+			// Older browsers without navigator.locks: freezing protection is best-effort.
+		}
+
 		const assistant = getAssistantOrDefault(chat?.assistantId);
 		const assistantMessage = addMessage(chatId, "assistant", "");
 
@@ -245,7 +267,10 @@ function Chat() {
 			for (let iteration = 0; iteration < MAX_TOOL_TURNS; iteration++) {
 				const toolAcc = new ToolCallAccumulator();
 				accumulated.content = "";
-				accumulated.thinking = "";
+				// Keep the reasoning trace across tool turns — resetting it here made each turn's
+				// thinking overwrite the previous one, so the visible trace vanished every time a
+				// tool ran. The separator lands lazily, only if this turn actually reasons.
+				let needsThinkingSeparator = accumulated.thinking.length > 0;
 
 				const stream = await openai.chat.completions.create(
 					{
@@ -270,7 +295,13 @@ function Chat() {
 					const reasoningContent = (deltaRecord.reasoning ?? deltaRecord.reasoning_content) as string | undefined;
 					const content = delta.content;
 
-					if (reasoningContent) accumulated.thinking += reasoningContent;
+					if (reasoningContent) {
+						if (needsThinkingSeparator) {
+							accumulated.thinking += "\n\n";
+							needsThinkingSeparator = false;
+						}
+						accumulated.thinking += reasoningContent;
+					}
 					if (content) accumulated.content += content;
 					toolAcc.add(delta.tool_calls as never);
 
@@ -333,7 +364,10 @@ function Chat() {
 					// and vanishing between tools. Only the friendly label is shown — never the tool
 					// name, arguments, or results.
 					setToolSteps((prev) => (toolStatus ? [...prev, toolStatus] : prev));
-					setToolStatus(TOOL_LABELS[call.name] ?? "Working…");
+					// Number the later round-trips so a multi-turn tool loop reads as deliberate
+					// steps instead of the response mysteriously restarting.
+					const toolLabel = TOOL_LABELS[call.name] ?? "Working…";
+					setToolStatus(iteration > 0 ? `${toolLabel} · step ${iteration + 1}` : toolLabel);
 					const opts = {
 						connectedApiUrl: env.LTAI_CONNECTED_API_URL,
 						chatApiKey: chatApiKey ?? "",
@@ -506,6 +540,9 @@ function Chat() {
 			setToolStatus(null);
 			setToolSteps([]);
 			abortRef.current = null;
+			releaseFreezeLock?.();
+			// If the user tabbed away while this generated, flag the finished answer in the title.
+			notifyResponseReady();
 		}
 	};
 

--- a/src/utils/background-notify.test.ts
+++ b/src/utils/background-notify.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { notifyResponseReady } from "./background-notify";
+
+// Minimal document stand-in for the node test environment.
+function makeDocument(hidden: boolean) {
+	const listeners = new Map<string, Set<() => void>>();
+	const doc = {
+		hidden,
+		visibilityState: hidden ? "hidden" : "visible",
+		title: "LibertAI",
+		addEventListener: (type: string, fn: () => void) => {
+			if (!listeners.has(type)) listeners.set(type, new Set());
+			listeners.get(type)!.add(fn);
+		},
+		removeEventListener: (type: string, fn: () => void) => {
+			listeners.get(type)?.delete(fn);
+		},
+		show() {
+			doc.hidden = false;
+			doc.visibilityState = "visible";
+			for (const fn of [...(listeners.get("visibilitychange") ?? [])]) fn();
+		},
+		listenerCount: (type: string) => listeners.get(type)?.size ?? 0,
+	};
+	return doc;
+}
+
+describe("notifyResponseReady", () => {
+	let doc: ReturnType<typeof makeDocument>;
+
+	beforeEach(() => {
+		doc = makeDocument(true);
+		vi.stubGlobal("document", doc);
+	});
+
+	afterEach(() => {
+		// Restore module state by simulating a return to the tab.
+		if (doc.hidden !== false) doc.show();
+		vi.unstubAllGlobals();
+	});
+
+	it("flags the title while hidden and restores it on return", () => {
+		notifyResponseReady();
+		expect(doc.title).toBe("✓ LibertAI");
+		doc.show();
+		expect(doc.title).toBe("LibertAI");
+		expect(doc.listenerCount("visibilitychange")).toBe(0);
+	});
+
+	it("does not stack flags across multiple completions", () => {
+		notifyResponseReady();
+		notifyResponseReady();
+		expect(doc.title).toBe("✓ LibertAI");
+		doc.show();
+		expect(doc.title).toBe("LibertAI");
+	});
+
+	it("does nothing when the tab is visible", () => {
+		doc.show();
+		notifyResponseReady();
+		expect(doc.title).toBe("LibertAI");
+		expect(doc.listenerCount("visibilitychange")).toBe(0);
+	});
+});

--- a/src/utils/background-notify.ts
+++ b/src/utils/background-notify.ts
@@ -2,6 +2,9 @@
 // restore the original title the moment they come back. Long thinking-model responses take
 // minutes, so users routinely tab away mid-generation — without a signal they have no way to
 // know the answer landed.
+//
+// The title is captured at flag time and restored verbatim: if the app ever starts setting
+// dynamic titles (e.g. the chat name), route those through here so a restore can't clobber them.
 
 let restorePending = false;
 

--- a/src/utils/background-notify.ts
+++ b/src/utils/background-notify.ts
@@ -1,0 +1,22 @@
+// Flag a finished response in the tab title when the user is looking at another tab, and
+// restore the original title the moment they come back. Long thinking-model responses take
+// minutes, so users routinely tab away mid-generation — without a signal they have no way to
+// know the answer landed.
+
+let restorePending = false;
+
+export function notifyResponseReady(): void {
+	if (typeof document === "undefined" || !document.hidden || restorePending) return;
+
+	const original = document.title;
+	document.title = `✓ ${original}`;
+	restorePending = true;
+
+	const restore = () => {
+		if (document.visibilityState !== "visible") return;
+		document.title = original;
+		document.removeEventListener("visibilitychange", restore);
+		restorePending = false;
+	};
+	document.addEventListener("visibilitychange", restore);
+}


### PR DESCRIPTION
## Context

Follow-up to #38. Even with the render/persist fixes merged, long Mega Mind (glm-5.2-thinking) responses could still appear to "block midflight, then show everything at once, then fire a new request". Investigation (curl timing probes against production + instrumented in-browser reproduction) showed the transport is healthy:

- The API streams evenly with the exact chat payload (tools included): 2000+ chunks over the whole generation, `text/event-stream; charset=utf-8` passthrough, no gateway buffering.
- One 200 POST per turn, zero retries. The "extra request" is the tool loop (the model verifying with `run_python`/`web_search`), which is invisible to the user.
- No hidden completion-token cap: an uncapped request ran to `finish_reason=stop` at 5,136 completion tokens.
- The remaining failure mode is UX + browser lifecycle: the thinking section is collapsed by default, so minutes of reasoning show only a spinner → the user tabs away → Chrome throttles/freezes the hidden tab (measured 57-60s event-loop stalls in an occluded tab) → the SSE read loop stalls midflight → returning to the tab dumps the backlog at once.

## Changes

1. **Live thinking preview** — while the model is reasoning (streaming, no answer yet), the tail of the thinking text (500-char cap, flat render cost) is shown under the collapsed THINKING header, so long reasoning phases visibly stream instead of looking frozen. The generic "Working…" fallback yields to the preview.
2. **Reasoning trace preserved across tool turns** — each tool-loop iteration used to overwrite the previous turn's thinking mid-response; turns are now separated by a blank line.
3. **Tab-freeze protection** — a shared Web Lock is held for the duration of a generation (lock-holding pages are exempt from Chrome tab freezing), and the tab title is flagged ("✓ …") when a response completes while the tab is hidden, restored on return.
4. **Tool-step transparency** — later round-trips are numbered in the status line ("Running Python… · step 2") so multi-turn tool use reads as deliberate steps.

## Verification

- `pnpm test`: 278/278 (new tests for the title-flag util)
- `pnpm lint`: clean; `pnpm build`: clean (at pinned `src/shared`)
- `pnpm e2e`: 37/37 including a new `thinking.spec.ts` that mocks a reasoning SSE completion and asserts the thinking section persists, expands, and the answer renders