### PR TITLE
Update anon chat notice to drive signups via feature unlocks

### DIFF
--- a/src/components/AnonChatNotice.tsx
+++ b/src/components/AnonChatNotice.tsx
@@ -8,8 +8,7 @@ const WARN_REMAINING = 3;
  * For logged-out users: a free-message meter above the composer. Shows nothing until the IP's
  * anonymous allowance is running low, a soft "N left — sign in" warning near the limit, and a
  * sign-in wall once it's used up. The CTA is always Sign in (not Upgrade) — these users have no
- * account yet. Messaging focuses on the features signing in unlocks (image generation,
- * text-to-speech, and more) rather than just a higher limit, to drive signup conversion.
+ * account yet.
  */
 export function AnonChatNotice() {
 	const navigate = useNavigate();
@@ -28,7 +27,7 @@ export function AnonChatNotice() {
 			<div className="mx-auto mb-3 max-w-3xl rounded-xl border border-border bg-card/60 p-4">
 				<p className="text-sm font-medium">You've used your {data.limit} free messages.</p>
 				<p className="mt-1 text-sm text-muted-foreground">
-					Sign in to unlock image generation, text-to-speech, and more — it's free.
+					Sign in to unlock image generation, text-to-speech and higher limits, it's free.
 				</p>
 				<div className="mt-3">
 					<Button size="sm" onClick={goSignIn}>
@@ -46,9 +45,7 @@ export function AnonChatNotice() {
 		<div className="mx-auto mb-3 max-w-3xl flex items-center justify-between gap-3 rounded-xl border border-amber-500/40 bg-amber-500/5 p-3">
 			<p className="text-sm">
 				{remaining} free message{remaining === 1 ? "" : "s"} left.{" "}
-				<span className="text-muted-foreground">
-					Sign in to unlock image generation, TTS, and more.
-				</span>
+				<span className="text-muted-foreground">Sign in to keep chatting for free.</span>
 			</p>
 			<Button size="sm" variant="outline" onClick={goSignIn}>
 				Sign in

--- a/src/components/AnonChatNotice.tsx
+++ b/src/components/AnonChatNotice.tsx
@@ -8,7 +8,8 @@ const WARN_REMAINING = 3;
  * For logged-out users: a free-message meter above the composer. Shows nothing until the IP's
  * anonymous allowance is running low, a soft "N left — sign in" warning near the limit, and a
  * sign-in wall once it's used up. The CTA is always Sign in (not Upgrade) — these users have no
- * account yet, and signing in is free with a higher limit.
+ * account yet. Messaging focuses on the features signing in unlocks (image generation,
+ * text-to-speech, and more) rather than just a higher limit, to drive signup conversion.
  */
 export function AnonChatNotice() {
 	const navigate = useNavigate();
@@ -26,7 +27,9 @@ export function AnonChatNotice() {
 		return (
 			<div className="mx-auto mb-3 max-w-3xl rounded-xl border border-border bg-card/60 p-4">
 				<p className="text-sm font-medium">You've used your {data.limit} free messages.</p>
-				<p className="mt-1 text-sm text-muted-foreground">Sign in to keep chatting — it's free, with a higher limit.</p>
+				<p className="mt-1 text-sm text-muted-foreground">
+					Sign in to unlock image generation, text-to-speech, and more — it's free.
+				</p>
 				<div className="mt-3">
 					<Button size="sm" onClick={goSignIn}>
 						Sign in
@@ -43,7 +46,9 @@ export function AnonChatNotice() {
 		<div className="mx-auto mb-3 max-w-3xl flex items-center justify-between gap-3 rounded-xl border border-amber-500/40 bg-amber-500/5 p-3">
 			<p className="text-sm">
 				{remaining} free message{remaining === 1 ? "" : "s"} left.{" "}
-				<span className="text-muted-foreground">Sign in to keep chatting for free.</span>
+				<span className="text-muted-foreground">
+					Sign in to unlock image generation, TTS, and more.
+				</span>
 			</p>
 			<Button size="sm" variant="outline" onClick={goSignIn}>
 				Sign in


### PR DESCRIPTION
## What

Updates the copy in `AnonChatNotice` (`src/components/AnonChatNotice.tsx`) to shift from a pure "you're limited, sign in for a higher limit" message to a value-driven "sign in to unlock features" pitch.

## Why

The previous copy framed signing in mostly as a way to raise the message limit. Logged-out users are unlikely to convert on "more of the same" alone. Highlighting concrete capabilities they gain — image generation, text-to-speech, and more — gives them a clearer reason to create an account, which should improve signup conversion. No free credits are promised; the Sign in CTA and redirect logic are unchanged.

## Changes

- **Limit-reached block (`!data.allowed`)**: subtitle now reads "Sign in to unlock image generation, text-to-speech, and more — it's free." (title and Sign in button unchanged).
- **Warning block (remaining ≤ WARN_REMAINING)**: now reads "N free message(s) left. Sign in to unlock image generation, TTS, and more." (Sign in button unchanged).
- **JSDoc**: updated to describe the new feature-unlock messaging approach instead of "higher limit".

Structure, styling, logic, and redirect behavior are unchanged — only text content and the JSDoc were modified.